### PR TITLE
create simple dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM rust:slim-bookworm
+
+RUN apt-get update && apt-get -y install libssl-dev pkg-config
+
+RUN mkdir /app
+WORKDIR /app
+ADD . .
+
+RUN cargo build
+
+ENTRYPOINT [ "cargo", "run", "--" ]
+CMD ["--url http://<gateway rest API>:4501", "--username 0E87CDA111", "--port 9199"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:slim-bookworm
 
-RUN apt-get update && apt-get -y install libssl-dev pkg-config
+RUN apt update && apt install -y libssl-dev pkg-config && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /app
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:slim-bookworm
+FROM rustlang/rust:nightly-slim
 
 RUN apt update && apt install -y libssl-dev pkg-config && rm -rf /var/lib/apt/lists/*
 
@@ -8,5 +8,5 @@ ADD . .
 
 RUN cargo build
 
-ENTRYPOINT [ "cargo", "run", "--" ]
-CMD ["--url http://<gateway rest API>:4501", "--username 0E87CDA111", "--port 9199"]
+ENTRYPOINT [ "cargo", "run", "--"]
+CMD ["--url http://<deconz-ip>:<port>", "--username <username-from-setup>", "--port 9199"]


### PR DESCRIPTION
Goal of this PR is to setup a working dockerfile for the project.

Currently its in draft state because I have problems compiling it. Is there a dependency to a certain Rust-version?

```
...
14.70    Compiling chrono v0.4.34
15.26    Compiling reqwest v0.11.24
15.96    Compiling deconz-exporter v0.1.0 (/app)
16.01 error[E0554]: `#![feature]` may not be used on the stable release channel
16.01  --> src/lib.rs:1:1
16.01   |
16.01 1 | #![feature(let_chains)]
16.01   | ^^^^^^^^^^^^^^^^^^^^^^^
16.01
16.12 For more information about this error, try `rustc --explain E0554`.
16.13 error: could not compile `deconz-exporter` (lib) due to 1 previous error
16.13 warning: build failed, waiting for other jobs to finish...
------
Dockerfile:9
--------------------
   7 |     ADD . .
   8 |
   9 | >>> RUN cargo build
  10 |
  11 |     ENTRYPOINT [ "cargo", "run", "--" ]
--------------------
ERROR: failed to solve: process "/bin/sh -c cargo build" did not complete successfully: exit code: 101
```